### PR TITLE
Fix DBus.Error.NotFound by adding ' ' for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ iwmenu -m custom --menu-command "my_custom_launcher {password_flag:--my-password
 This example demonstrates enabling all available features in custom mode with `fuzzel`.
 
 ```shell
-iwmenu -m custom --menu-command "fuzzel -d -p '{prompt}' {password_flag:--password}"
+iwmenu -m custom --menu-command "fuzzel -d -p '{prompt}' '{password_flag:--password}'"
 ```
 
 ### Available Options


### PR DESCRIPTION
iwmenu -m custom --menu-command "wofi -d -p '{prompt}' {password_flag:--password}"
Error: org.freedesktop.DBus.Error.NotFound: No matching method found

updated 

![image](https://github.com/user-attachments/assets/4d7542e1-7c69-4094-8ffa-c1c45662bd31)
