### PR TITLE
feat: add nix overlay and flake input instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ An executable file will be generated at `target/release/iwmenu`, which you can t
 
 ### Nix
 
+#### Using Flake Input (Recommended)
+
 Add the flake as an input:
 
 ```nix
@@ -80,6 +82,27 @@ Install the package:
 { inputs, ... }:
 {
   environment.systemPackages = [ inputs.iwmenu.packages.${pkgs.system}.default ];
+}
+```
+
+#### Using Overlay
+
+Add the flake as an input and apply the overlay:
+
+```nix
+inputs.iwmenu.url = "github:e-tho/iwmenu";
+```
+
+Apply the overlay in your system configuration:
+
+```nix
+{ inputs, ... }:
+{
+  nixpkgs.overlays = [ inputs.iwmenu.overlays.default ];
+  
+  environment.systemPackages = with pkgs; [
+    iwmenu
+  ];
 }
 ```
 


### PR DESCRIPTION
Add comprehensive documentation for using the iwmenu overlay in Nix
configurations. This provides users with an alternative installation
method alongside the existing flake input approach.

Changes:
- Add "Using Overlay" subsection with system and standalone examples
- Show how to use pkgs.iwmenu after applying the overlay
- Keep existing flake input method as recommended approach
- Provide clear examples for both installation methods

This gives users more flexibility in how they integrate iwmenu into
their Nix configurations, especially useful for those managing
multiple overlays or preferring standard pkgs attribute access.