### PR TITLE
fix: remove non-existent -y flag on walker

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -112,9 +112,6 @@ impl Launcher {
                 if let Some(hint_text) = placeholder {
                     cmd.arg("-p").arg(hint_text);
                 }
-                if password_mode {
-                    cmd.arg("-y");
-                }
                 cmd
             }
             LauncherCommand::Custom { program, args } => {


### PR DESCRIPTION
Walker does not support the `-y` flag.
Using `-n` (to hide input) causes a runtime error:

    Error during app execution: Failed to connect to new network: ignacio's A36
    Caused by:
        net.connman.iwd.InvalidFormat: Argument format is invalid
    Error: Fatal error in application: Failed to connect to new network: ignacio's A36

To restore basic connection functionality, this commit removes the `-y` flag. This favors a working connection over hidden input until a proper solution can be found.

Closes: https://github.com/e-tho/iwmenu/issues/21