### PR TITLE
Add missing fallback to lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ extern crate rust_i18n;
 #[macro_use]
 mod macros;
 
-i18n!("locales");
+i18n!("locales", fallback = "en");
 
 pub mod app;
 pub mod icons;


### PR DESCRIPTION
A missing fallback in `lib.rs` caused the locale to not load correctly.

Old behaviour:
<img width="490" height="110" alt="image" src="https://github.com/user-attachments/assets/6f8cf9cf-8034-4309-a9a4-36fea26af4d8" />

Now:
<img width="489" height="122" alt="image" src="https://github.com/user-attachments/assets/e4816cf2-2efb-4983-8726-976742b0431c" />
